### PR TITLE
Fix: Update deprecated HA APIs for compatibility with HA 2022.5+

### DIFF
--- a/custom_components/adax/__init__.py
+++ b/custom_components/adax/__init__.py
@@ -1,22 +1,16 @@
 """The Adax heater integration."""
-
-
 async def async_setup(hass, config):
     """Set up the Adax platform."""
     return True
 
-
 async def async_setup_entry(hass, entry):
     """Set up the Adax heater."""
-    hass.async_create_task(
-        hass.config_entries.async_forward_entry_setup(entry, "climate")
-    )
+    await hass.config_entries.async_forward_entry_setups(entry, ["climate"])
     return True
-
 
 async def async_unload_entry(hass, config_entry):
     """Unload a config entry."""
-    unload_ok = await hass.config_entries.async_forward_entry_unload(
-        config_entry, "climate"
+    unload_ok = await hass.config_entries.async_unload_platforms(
+        config_entry, ["climate"]
     )
     return unload_ok

--- a/custom_components/adax/climate.py
+++ b/custom_components/adax/climate.py
@@ -4,17 +4,14 @@ import logging
 from adax import Adax
 import voluptuous as vol
 from homeassistant.components.climate import PLATFORM_SCHEMA, ClimateEntity
-from homeassistant.components.climate.const import (
-    HVAC_MODE_HEAT,
-    HVAC_MODE_OFF,
-    SUPPORT_TARGET_TEMPERATURE,
-)
+from homeassistant.components.climate import HVACMode
+from homeassistant.components.climate import ClimateEntityFeature
 from homeassistant.const import (
     ATTR_TEMPERATURE,
     CONF_PASSWORD,
     PRECISION_WHOLE,
-    TEMP_CELSIUS,
 )
+from homeassistant.const import UnitOfTemperature
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
@@ -61,7 +58,7 @@ class AdaxDevice(ClimateEntity):
     @property
     def supported_features(self):
         """Return the list of supported features."""
-        return SUPPORT_TARGET_TEMPERATURE
+        return ClimateEntityFeature.TARGET_TEMPERATURE
 
     @property
     def unique_id(self):
@@ -77,31 +74,31 @@ class AdaxDevice(ClimateEntity):
     def hvac_mode(self):
         """Return hvac operation ie. heat, cool mode."""
         if self._heater_data["heatingEnabled"]:
-            return HVAC_MODE_HEAT
-        return HVAC_MODE_OFF
+            return HVACMode.HEAT
+        return HVACMode.OFF
 
     @property
     def icon(self):
         """Return nice icon for heater."""
-        if self.hvac_mode == HVAC_MODE_HEAT:
+        if self.hvac_mode == HVACMode.HEAT:
             return "mdi:radiator"
         return "mdi:radiator-off"
 
     @property
     def hvac_modes(self):
         """Return the list of available hvac operation modes."""
-        return [HVAC_MODE_HEAT, HVAC_MODE_OFF]
+        return [HVACMode.HEAT, HVACMode.OFF]
 
     async def async_set_hvac_mode(self, hvac_mode):
         """Set hvac mode."""
-        if hvac_mode == HVAC_MODE_HEAT:
+        if hvac_mode == HVACMode.HEAT:
             temperature = max(
                 self.min_temp, self._heater_data.get("targetTemperature", self.min_temp)
             )
             await self._adax_data_handler.set_room_target_temperature(
                 self._heater_data["id"], temperature, True
             )
-        elif hvac_mode == HVAC_MODE_OFF:
+        elif hvac_mode == HVACMode.OFF:
             await self._adax_data_handler.set_room_target_temperature(
                 self._heater_data["id"], self.min_temp, False
             )
@@ -112,7 +109,7 @@ class AdaxDevice(ClimateEntity):
     @property
     def temperature_unit(self):
         """Return the unit of measurement which this device uses."""
-        return TEMP_CELSIUS
+        return UnitOfTemperature.CELSIUS
 
     @property
     def min_temp(self):

--- a/custom_components/adax/config_flow.py
+++ b/custom_components/adax/config_flow.py
@@ -1,11 +1,9 @@
 """Adds config flow for Adax integration."""
 import logging
-
 import voluptuous as vol
 from homeassistant import config_entries, core, exceptions
 from homeassistant.const import CONF_PASSWORD
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
-
 from adax import get_adax_token
 from .const import ACCOUNT_ID, DOMAIN
 
@@ -15,18 +13,15 @@ DATA_SCHEMA = vol.Schema(
     {vol.Required(ACCOUNT_ID): int, vol.Required(CONF_PASSWORD): str}
 )
 
-
 async def validate_input(hass: core.HomeAssistant, account_id, password):
     """Validate the user input allows us to connect."""
     for entry in hass.config_entries.async_entries(DOMAIN):
         if entry.data[ACCOUNT_ID] == account_id:
             raise AlreadyConfigured
-
     token = await get_adax_token(async_get_clientsession(hass), account_id, password)
     if token is None:
         _LOGGER.info("Adax: Failed to login to retrieve token")
         raise CannotConnect
-
 
 class AdaxConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Adax integration."""
@@ -37,36 +32,30 @@ class AdaxConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     async def async_step_user(self, user_input=None):
         """Handle the initial step."""
         errors = {}
-
         if user_input is not None:
             try:
                 account_id = user_input[ACCOUNT_ID]
                 password = user_input[CONF_PASSWORD].replace(" ", "")
                 await validate_input(self.hass, account_id, password)
-                unique_id = account_id
+                unique_id = str(account_id)
                 await self.async_set_unique_id(unique_id)
                 self._abort_if_unique_id_configured()
-
                 return self.async_create_entry(
                     title=unique_id,
                     data={ACCOUNT_ID: account_id, CONF_PASSWORD: password},
                 )
-
             except AlreadyConfigured:
                 return self.async_abort(reason="already_configured")
             except CannotConnect:
                 errors["base"] = "connection_error"
-
         return self.async_show_form(
             step_id="user",
             data_schema=DATA_SCHEMA,
             errors=errors,
         )
 
-
 class CannotConnect(exceptions.HomeAssistantError):
     """Error to indicate we cannot connect."""
-
 
 class AlreadyConfigured(exceptions.HomeAssistantError):
     """Error to indicate host is already configured."""


### PR DESCRIPTION
This integration stopped working on modern Home Assistant versions due to several deprecated APIs. Fixes:
   
   - async_forward_entry_setup → async_forward_entry_setups
   - async_forward_entry_unload → async_unload_platforms
   - HVAC_MODE_* → HVACMode enum
   - SUPPORT_TARGET_TEMPERATURE → ClimateEntityFeature.TARGET_TEMPERATURE
   - TEMP_CELSIUS → UnitOfTemperature.CELSIUS
   - unique_id cast to str
   
   Tested and working on HA 2025.x.